### PR TITLE
Various fixes

### DIFF
--- a/dr.css
+++ b/dr.css
@@ -38,6 +38,10 @@ h5:hover a.dr-sourceline {
 .dr-type {
     float: left;
 }
+.dr-title {
+    float: left;
+    margin: 0 8px 0 0;
+}
 .dr-type em,
 .dr-returns em,
 .dr-property em {

--- a/dr.js
+++ b/dr.js
@@ -208,7 +208,7 @@ if (!files.length) {
         return 1;
     });
 
-    var temp = fs.readFileSync(json.template || "template.dot", "utf-8"),
+    var temp = fs.readFileSync(json.template || (__dirname + "/template.dot"), "utf-8"),
         betterTOC = [];
     for (i = 0, ii = toc.length; i < ii; i++) {
         if (i == ii - 1 || toc[i].name != toc[i + 1].name) {

--- a/dr.js
+++ b/dr.js
@@ -220,6 +220,7 @@ if (!files.length) {
     var html = temp({
         title: title,
         subtitle: json.subtitle || '',
+        scripts: scripts,
         out: sec,
         toc: betterTOC
     });

--- a/dr.js
+++ b/dr.js
@@ -218,6 +218,8 @@ if (!files.length) {
     dot.templateSettings.strip = false;
     temp = dot.template(temp);
     var html = temp({
+        title: title,
+        subtitle: json.subtitle || '',
         out: sec,
         toc: betterTOC
     });

--- a/template.dot
+++ b/template.dot
@@ -104,8 +104,9 @@
     </div>
     <script src="//use.edgefonts.net/source-sans-pro:n3,n4,n6;source-code-pro:n3.js"></script>
     <script src="js/prism.js"></script>
-    <script src="raphael.js"></script>
-    <script src="reference.js"></script>
+    {{~ it.scripts :scriptPath }}
+    <script src="{{= scriptPath }}"></script>
+    {{~}}
 <script>!function(e){if(e){for(var t=function(e,t){var n=t.toUpperCase().split(""),r=n.shift(),a=RegExp("^["+r.toLowerCase()+r+"][a-z]*"+n.join("[a-z]*")+"[a-z]*$")
 return!!(e+"").match(a)},n=function(e,n){e+="",n+=""
 var r,a=0

--- a/template.dot
+++ b/template.dot
@@ -3,7 +3,7 @@
     <head>
         <meta charset="utf-8">
         <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
-        <title>Dr.js API Reference</title>
+        <title>{{= (it.title || '') + ' ' + (it.subtitle || 'API Reference') }}</title>
         <meta name="viewport" content="user-scalable=no,initial-scale = 1.0,maximum-scale = 1.0">
         <link rel="stylesheet" href="fonts/stylesheet.css">
         <link rel="stylesheet" href="css/topcoat-desktop-light.css">
@@ -35,8 +35,8 @@
                   <header id="main-header">
                       <div class="max-width">
                           <hgroup>
-                              <h1>Dr.js</h1>
-                              <p>API Reference</p>
+                              <h1>{{= it.title || '' }}</h1>
+                              <p>{{= it.subtitle || 'API Reference' }}</p>
                           </hgroup>
                       </div>
                   </header>


### PR DESCRIPTION
- The title and subtitle are passed to the template function from the JSON file.
  - The title of the generated document is `(it.title || '') + ' ' + (it.subtitle || 'API Reference')`
  - The HTML heading and sub heading are `<h1>{{= it.title || '' }}</h1> <p>{{= it.subtitle || 'API Reference' }}</p>`
- Scripts in the `scripts` array of the JSON config file are included in the generated HTML as described in `dr.js`'s documentaion (this functionality was lost in the transition to doT templating).
- "Returns:" in the generated documentation now to the left of the (object type)
  - Before ![image](https://f.cloud.github.com/assets/1679746/1827603/28acf3be-723a-11e3-8bb1-7d15bd06d7b5.png)
  - After ![image](https://f.cloud.github.com/assets/1679746/1827637/71cbe59a-723b-11e3-909c-e0092e64f00e.png)
- If a template is not given in the JSON config, `template.dot` is taken from Dr.js's directory, not the directory the command was run in.
